### PR TITLE
Fix/chain adapter and reset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 node_modules
 package-lock.json
 coverage
+.nyc_output

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 .private
 coverage
+.nyc_output
 node_modules
 src
 .gitignore

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brusc",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "IOC Container for Effective JS development",
   "main": "dist",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "phoenix": "rm -Rf node_modules && rm -Rf package-lock.json && npm i",
     "prepack": "npm run clean && npm run build",
     "test": "mocha --recursive --require @babel/register \"src/test/**/*Test.js\"",
-    "coverage": "istanbul cover --report html _mocha -- ./src/test* --recursive --require @babel/register",
-    "coverage:ci": "istanbul cover _mocha -- ./src/test* --recursive --require @babel/register && codecov",
+    "coverage": "nyc --reporter=html --exclude=\"src/test\" npm run test",
+    "coverage:ci": "nyc --reporter=cobertura --exclude=\"src/test\" npm run test && codecov",
     "lint": "sui-lint js",
     "check": "npm run lint && npm run test",
     "build": "npm run clean && babel src/main --out-dir dist"
@@ -34,8 +34,8 @@
     "babel-loader": "^8.0.6",
     "chai": "^4.2.0",
     "codecov": "^3.6.1",
-    "istanbul": "1.1.0-alpha.1",
-    "mocha": "5.2.0"
+    "mocha": "5.2.0",
+    "nyc": "^15.0.0"
   },
   "babel": {
     "plugins": [
@@ -50,5 +50,6 @@
   "prettier": "./node_modules/@s-ui/lint/.prettierrc.js",
   "stylelint": {
     "extends": "./node_modules/@s-ui/lint/stylelint.config.js"
-  }
+  },
+  "dependencies": {}
 }

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -2,9 +2,15 @@ import {IOC} from './ioc/IOC'
 
 const shared = new IOC()
 
-const iocModule = ({module, initializer, adapter, chain = false} = {}) =>
-  shared.module({module, initializer, adapter, chain})
+const iocReset = module => shared.clear(module)
+
+const iocModule = ({
+  module,
+  initializer = () => null,
+  adapter = instance => instance,
+  chain = false
+} = {}) => shared.module({module, initializer, adapter, chain})
 
 const iocInjector = module => shared.injector(module)
 
-export {iocModule, iocInjector}
+export {iocModule, iocInjector, iocReset}

--- a/src/main/ioc/IOC.js
+++ b/src/main/ioc/IOC.js
@@ -24,6 +24,10 @@ class IOC {
     }
   }
 
+  clear(module) {
+    this._modules.delete(module)
+  }
+
   injector(module) {
     this._guardModuleExists(module)
     return key => this._modules.get(module).container.provide(key)
@@ -36,7 +40,7 @@ class IOC {
       container = new DefaultContainer({module, adapter})
     } else {
       if (old.chain) {
-        container = new ChainContainer({
+        container = ChainContainer.create({
           module,
           adapter,
           chained: old.container

--- a/src/main/ioc/container/ChainContainer.js
+++ b/src/main/ioc/container/ChainContainer.js
@@ -7,6 +7,12 @@ class ChainContainer extends DefaultContainer {
     this._chained = chained
   }
 
+  static create({module, adapter, chained}) {
+    const reAdapter = (instance, key, module) =>
+      adapter(chained.adapter(instance, key, module), key, module)
+    return new ChainContainer({module, adapter: reAdapter, chained})
+  }
+
   provide(key) {
     try {
       return this._chained.has(key)

--- a/src/main/ioc/container/DefaultContainer.js
+++ b/src/main/ioc/container/DefaultContainer.js
@@ -7,7 +7,7 @@ import {InstantiationError} from '../error/InstantiationError'
 import {InvalidAdapterError} from '../error/InvalidAdapterError'
 
 class DefaultContainer extends Container {
-  constructor({module, adapter = instance => instance}) {
+  constructor({module, adapter}) {
     super()
     this._guardAdapterIsAFunction(adapter)
     this._module = module
@@ -18,6 +18,10 @@ class DefaultContainer extends Container {
     this._eagers = new Set()
     this._singletonProvider = () => key => this._provideSingleton(key)
     this._prototypeProvider = () => key => this._providePrototype(key)
+  }
+
+  get adapter() {
+    return this._adapter
   }
 
   singleton(key, builder, lazy = true) {

--- a/src/test/sample/core/Sample.js
+++ b/src/test/sample/core/Sample.js
@@ -8,7 +8,7 @@ class Sample {
     singletonB = inject(SampleSingletonClass),
     prototypeA = inject(SamplePrototypeClass),
     prototypeB = inject(SamplePrototypeClass),
-    textFunction = inject('sampleSingletonFactory')
+    textFunction = inject('sampleSingletonFunction')
   } = {}) {
     this._singletonA = singletonA
     this._singletonB = singletonB

--- a/src/test/sample/core/bootstrap/SampleInitializer.js
+++ b/src/test/sample/core/bootstrap/SampleInitializer.js
@@ -3,9 +3,9 @@ import {IOC_CONTEXT} from '../context/ioc'
 import {SampleInterface} from '../SampleInterface'
 import {SampleInterfaceImpl} from '../SampleInterfaceImpl'
 import {SampleSingletonClass} from '../SampleSingletonClass'
-import {sampleSingletonFactory} from '../sampleSingletonFactoryFunction'
+import {sampleSingletonFactoryFunction} from '../sampleSingletonFactoryFunction'
 import {SamplePrototypeClass} from '../SamplePrototypeClass'
-import {samplePrototypeFactory} from '../samplePrototypeFactoryFunction'
+import {samplePrototypeFactoryFunction} from '../samplePrototypeFactoryFunction'
 import {Sample} from '../Sample'
 
 class SampleInitializer {
@@ -15,9 +15,13 @@ class SampleInitializer {
       initializer: ({singleton, prototype}) => {
         singleton(SampleInterface, () => new SampleInterfaceImpl())
         singleton(SampleSingletonClass, () => new SampleSingletonClass())
-        singleton('sampleSingletonFactory', () => sampleSingletonFactory())
+        singleton('sampleSingletonFunction', () =>
+          sampleSingletonFactoryFunction()
+        )
         prototype(SamplePrototypeClass, () => new SamplePrototypeClass())
-        prototype('samplePrototypeFactory', () => samplePrototypeFactory())
+        prototype('samplePrototypeFunction', () =>
+          samplePrototypeFactoryFunction()
+        )
       }
     })
     return new Sample()

--- a/src/test/sample/core/samplePrototypeFactoryFunction.js
+++ b/src/test/sample/core/samplePrototypeFactoryFunction.js
@@ -1,5 +1,5 @@
 let state = 1
-export const samplePrototypeFactory = () => {
+export const samplePrototypeFactoryFunction = () => {
   const _state = ++state % 2
   const _regex = new RegExp(`.{${_state + 1}}`)
   return (text = '') => `[${text.replace(_regex, '*')}]`

--- a/src/test/sample/core/sampleSingletonFactoryFunction.js
+++ b/src/test/sample/core/sampleSingletonFactoryFunction.js
@@ -1,6 +1,6 @@
 import {inject} from './context/ioc'
 
-export const sampleSingletonFactory = ({
-  open = inject('samplePrototypeFactory'),
-  close = inject('samplePrototypeFactory')
+export const sampleSingletonFactoryFunction = ({
+  open = inject('samplePrototypeFunction'),
+  close = inject('samplePrototypeFunction')
 } = {}) => text => `${open(text)}${text}${close(text)}`


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

Changes:
* add a iocReset method to completely remove a module from the context, for external testing purposes (needed to test performance of this IoC container vs those that are not keeping the context)
* replace istambul (discontinued) by nyc for coverage 
* fix the chain container to apply the instance adapter through the chain (needed when creating performance test proxies from the outside)