### PR TITLE
Fix/support old browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@babel/plugin-proposal-class-properties": "7.13.0",
     "@babel/plugin-transform-classes": "7.13.0",
     "@babel/plugin-transform-modules-commonjs": "7.13.8",
+    "@babel/preset-env": "7.14.2",
     "@babel/register": "7.13.8",
     "@babel/runtime": "7.13.9",
     "@s-ui/lint": "3",
@@ -45,6 +46,17 @@
     "versiona": "4"
   },
   "babel": {
+    "presets": [
+      [
+        "@babel/preset-env",
+        {
+          "targets": {
+            "ie": "11",
+            "safari": "9"
+          }
+        }
+      ]
+    ],
     "plugins": [
       "@babel/plugin-transform-modules-commonjs",
       "@babel/plugin-proposal-class-properties",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "plugins": [
       "@babel/plugin-transform-modules-commonjs",
       "@babel/plugin-proposal-class-properties",
-      "@babel/plugin-transform-classes"
+      "@babel/plugin-transform-classes",
+      ["@babel/plugin-proposal-private-methods", { "loose": false }]
     ]
   },
   "eslintConfig": {


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

Support old browsers (ie11, safari 9), due to detected bug in built JS with `let` usage:
![image](https://user-images.githubusercontent.com/20399660/118961873-16c86780-b965-11eb-8adb-9cd3526febdd.png)

![image](https://user-images.githubusercontent.com/20399660/118961914-2051cf80-b965-11eb-801d-0a97cdfdfba9.png)

## Expected behavior
<!--- Add information of what's expected to happen when this is merged -->

![image](https://user-images.githubusercontent.com/20399660/118961994-352e6300-b965-11eb-92c0-91b7705c0ebb.png)

## Memetized description
<!--- Mandatory gif, try https://giphy.com/  -->
![mandatory](https://media.giphy.com/media/Rk927btUSH5eW0Hlbs/giphy.gif)